### PR TITLE
Update Docker image to Java 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM openjdk:17-alpine
+FROM openjdk:21-jdk-slim
 
 COPY target/goods-0.0.1.jar /usr/local/lib/run.jar
 
-RUN apk add --no-cache tzdata
-ENV TZ America/Fortaleza
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tzdata \
+    && rm -rf /var/lib/apt/lists/*
+ENV TZ=America/Fortaleza
 
 WORKDIR /
 ENTRYPOINT ["java", "-XX:+UseSerialGC", "-Xss512k", "-XX:MaxRAM=256m", "-jar", "/usr/local/lib/run.jar"]


### PR DESCRIPTION
## Summary
- use `openjdk:21-jdk-slim` as Docker base image
- install tzdata via apt-get

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fcebe7a0832493a2530a25038386